### PR TITLE
달력 각 날짜 크기 변경

### DIFF
--- a/app/src/main/java/com/hane24/hoursarenotenough24/inoutlog/DateSelectDialog.kt
+++ b/app/src/main/java/com/hane24/hoursarenotenough24/inoutlog/DateSelectDialog.kt
@@ -1,5 +1,6 @@
 package com.hane24.hoursarenotenough24.inoutlog
 
+import android.content.res.Configuration
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -45,11 +46,12 @@ fun DateSelectDialog(
 
     Dialog(onDismissRequest = { onDismissRequest() }) {
         Card(
+            backgroundColor = colorResource(id = R.color.overview_in_color),
+            shape = RoundedCornerShape(16.dp),
             modifier = Modifier
                 .fillMaxWidth()
                 .height(200.dp)
                 .padding(16.dp),
-            shape = RoundedCornerShape(16.dp),
         ) {
             Column(
                 verticalArrangement = Arrangement.Center,
@@ -146,6 +148,7 @@ fun DateSelectDialog(
 
 @Composable
 @Preview(showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun DateSelectDialogPreview() {
     DateSelectDialog(2023, 11, onDismissRequest = {}, onConfirmation = { _, _ -> })
 }

--- a/app/src/main/java/com/hane24/hoursarenotenough24/inoutlog/LogCalendarScreen.kt
+++ b/app/src/main/java/com/hane24/hoursarenotenough24/inoutlog/LogCalendarScreen.kt
@@ -421,6 +421,7 @@ private fun LogTableOfDayHeader(modifier: Modifier = Modifier) {
             fontSize = 15.sp,
             textAlign = TextAlign.Center,
             fontWeight = FontWeight.Bold,
+            color = colorResource(id = R.color.etc_title_color),
             modifier = Modifier.width(80.dp)
         )
         Text(
@@ -428,6 +429,7 @@ private fun LogTableOfDayHeader(modifier: Modifier = Modifier) {
             fontSize = 15.sp,
             textAlign = TextAlign.Center,
             fontWeight = FontWeight.Bold,
+            color = colorResource(id = R.color.etc_title_color),
             modifier = Modifier.width(80.dp)
         )
         Text(
@@ -435,6 +437,7 @@ private fun LogTableOfDayHeader(modifier: Modifier = Modifier) {
             fontSize = 15.sp,
             textAlign = TextAlign.Center,
             fontWeight = FontWeight.Bold,
+            color = colorResource(id = R.color.etc_title_color),
             modifier = Modifier.width(80.dp)
         )
     }
@@ -643,6 +646,7 @@ private fun TableDateAndAccumulationTimePreview() {
 
 @Composable
 @Preview(showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun LogTableOfDayHeaderPreview() {
     LogTableOfDayHeader()
 }

--- a/app/src/main/java/com/hane24/hoursarenotenough24/inoutlog/LogCalendarScreen.kt
+++ b/app/src/main/java/com/hane24/hoursarenotenough24/inoutlog/LogCalendarScreen.kt
@@ -186,19 +186,26 @@ private fun CalendarItem(
     item: CalendarItem,
     dayOnClick: (Int?) -> Unit,
 ) {
-    Text(
-        text = item.dayText,
-        fontSize = 14.sp,
-        color = colorResource(id = R.color.etc_title_color),
-        textAlign = TextAlign.Center,
+    Box(
+        contentAlignment = Alignment.Center,
         modifier = Modifier
+            .size(40.dp)
             .clickableWithoutRipple(
                 onClick = { dayOnClick(item.dayText.toIntOrNull()) }
             )
-            .background(colorResource(id = item.background), RoundedCornerShape(10.dp))
-            .size(40.dp)
-            .wrapContentHeight(align = Alignment.CenterVertically)
-    )
+    ) {
+        Text(
+            text = item.dayText,
+            fontSize = 14.sp,
+            color = colorResource(id = R.color.etc_title_color),
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .size(30.dp)
+                .background(colorResource(id = item.background), RoundedCornerShape(10.dp))
+                .wrapContentHeight(align = Alignment.CenterVertically)
+        )
+
+    }
 }
 
 @Composable
@@ -206,38 +213,51 @@ private fun CalendarSelectedItem(
     item: CalendarItem,
     dayOnClick: (Int?) -> Unit,
 ) {
-    Text(
-        text = item.dayText,
-        fontSize = 14.sp,
-        fontWeight = FontWeight.Bold,
-        color = colorResource(id = R.color.selected_text_color),
-        textAlign = TextAlign.Center,
+    Box(
+        contentAlignment = Alignment.Center,
         modifier = Modifier
+            .size(40.dp)
             .clickableWithoutRipple(
                 onClick = { dayOnClick(item.dayText.toIntOrNull()) }
             )
-            .background(
-                colorResource(id = R.color.selected_background_color), CircleShape
-            )
-            .size(40.dp)
-            .wrapContentHeight(align = Alignment.CenterVertically)
-    )
+    ) {
+        Text(
+            text = item.dayText,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Bold,
+            color = colorResource(id = R.color.selected_text_color),
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .size(30.dp)
+                .background(
+                    colorResource(id = R.color.selected_background_color), CircleShape
+                )
+                .wrapContentHeight(align = Alignment.CenterVertically)
+        )
+
+    }
 }
 
 @Composable
 private fun CalendarNextDayItem(
     item: CalendarItem,
 ) {
-    Text(
-        text = item.dayText,
-        fontSize = 14.sp,
-        color = colorResource(id = R.color.next_day_text),
-        textAlign = TextAlign.Center,
+    Box(
+        contentAlignment = Alignment.Center,
         modifier = Modifier
-            .background(Color.Transparent)
             .size(40.dp)
-            .wrapContentHeight(align = Alignment.CenterVertically)
-    )
+    ) {
+        Text(
+            text = item.dayText,
+            fontSize = 14.sp,
+            color = colorResource(id = R.color.next_day_text),
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .background(Color.Transparent)
+                .size(30.dp)
+                .wrapContentHeight(align = Alignment.CenterVertically)
+        )
+    }
 }
 
 @Composable
@@ -245,23 +265,28 @@ private fun CalendarTodayItem(
     item: CalendarItem,
     dayOnClick: (Int?) -> Unit,
 ) {
-    Text(
-        text = item.dayText,
-        fontSize = 14.sp,
-        color = colorResource(id = R.color.today_select_color),
-        textAlign = TextAlign.Center,
+    Box(
+        contentAlignment = Alignment.Center,
         modifier = Modifier
-            .clickableWithoutRipple(onClick = { dayOnClick(item.dayText.toIntOrNull()) })
-            .background(Color.Transparent)
-            .border(
-                2.dp,
-                colorResource(id = R.color.today_select_color),
-                RoundedCornerShape(10.dp)
-            )
             .size(40.dp)
-            .wrapContentHeight(align = Alignment.CenterVertically)
-    )
-}
+            .clickableWithoutRipple(onClick = { dayOnClick(item.dayText.toIntOrNull()) })
+    ){
+        Text(
+            text = item.dayText,
+            fontSize = 14.sp,
+            color = colorResource(id = R.color.today_select_color),
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .background(Color.Transparent)
+                .border(
+                    2.dp,
+                    colorResource(id = R.color.today_select_color),
+                    RoundedCornerShape(10.dp)
+                )
+                .size(30.dp)
+                .wrapContentHeight(align = Alignment.CenterVertically)
+        )
+    }}
 
 @Composable
 private fun LogCalendarRow(
@@ -277,7 +302,7 @@ private fun LogCalendarRow(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
             .fillMaxWidth()
-            .padding(vertical = 6.dp)
+            .padding(vertical = 2.dp)
     ) {
         for (item in items) {
             val itemDate = item.dayText.toIntOrNull()
@@ -495,7 +520,7 @@ fun LogCalendarScreen(modifier: Modifier = Modifier, viewModel: LogViewModel) {
                     .fillMaxWidth()
                     .defaultMinSize(minHeight = 200.dp)
             )
-        } else {/* TODO loading animation view */
+        } else {
             LogCalendarGrid(
                 gridItems = viewModel.tagLogs.asCalendarItems(viewModel.year, viewModel.month),
                 dayOnClick = { viewModel.updateDay(it) },
@@ -550,6 +575,7 @@ private fun DayOfWeekRowPreview() {
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun CalendarItemPreview() {
     Row(
+        verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceAround,
         modifier = Modifier
             .fillMaxWidth()
@@ -587,14 +613,14 @@ private fun LogCalendarPreview() {
         R.color.calendar_color3,
         R.color.calendar_color4,
     )
-    val gridItems = List(35) { i ->
-        if (i < 3 || 32 < i) {
+    val gridItems = List(42) { i ->
+        if (i < 5 || 35 < i) {
             CalendarItem("", R.color.transparent)
         } else {
-            CalendarItem("${i - 2}", colorArray.random())
+            CalendarItem("${i - 4}", colorArray.random())
         }
     }
-    LogCalendarGrid(gridItems = gridItems, dayOnClick = {}, year = 2023, month = 11, day = 1)
+    LogCalendarGrid(gridItems = gridItems, dayOnClick = {}, year = 2023, month = 12, day = 1)
 }
 
 @Composable
@@ -698,9 +724,9 @@ private fun List<TagLog>.asCalendarItems(year: Int, month: Int): List<CalendarIt
         }
     }
     calendar.set(year, month - 1, 1)
-    val itemCount = calendar.calculateDaysOfMonth() + (7 - calendar.calculateDaysOfMonth() % 7)
     val startIndex = calendar.get(Calendar.DAY_OF_WEEK) - 1
     val lastIndex = startIndex + calendar.calculateDaysOfMonth() - 1
+    val itemCount = (lastIndex + 7) / 7 * 7
     return List(itemCount) {
         if (it < startIndex || lastIndex < it) {
             CalendarItem("", R.color.transparent)

--- a/app/src/main/java/com/hane24/hoursarenotenough24/overview/TargetTimeModalDialog.kt
+++ b/app/src/main/java/com/hane24/hoursarenotenough24/overview/TargetTimeModalDialog.kt
@@ -1,5 +1,6 @@
 package com.hane24.hoursarenotenough24.overview
 
+import android.content.res.Configuration
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -39,11 +40,12 @@ fun TargetTimeModalDialog(
 ) {
     Dialog(onDismissRequest = { onDismissRequest() }) {
         Card(
+            backgroundColor = colorResource(id = R.color.overview_in_color),
+            shape = RoundedCornerShape(16.dp),
             modifier = Modifier
                 .fillMaxWidth()
                 .height(200.dp)
                 .padding(16.dp),
-            shape = RoundedCornerShape(16.dp),
         ) {
             var targetTimeValue by remember { mutableIntStateOf(currentTargetTime - 12) }
 
@@ -113,6 +115,7 @@ fun TargetTimeModalDialog(
 }
 
 @Preview
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun TargetTimeModalDialogPreview() {
     TargetTimeModalDialog(currentTargetTime = 12, onDismissRequest = { /*TODO*/ }, onConfirmation = {})

--- a/app/src/main/java/com/hane24/hoursarenotenough24/reissue/ReissueDialog.kt
+++ b/app/src/main/java/com/hane24/hoursarenotenough24/reissue/ReissueDialog.kt
@@ -1,5 +1,6 @@
 package com.hane24.hoursarenotenough24.reissue
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -121,12 +122,14 @@ fun ReissueDialog(
 
 @Composable
 @Preview(showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun ReissueDialogPreview() {
     ReissueDialog(isApply = true, onDismissRequest = {}, onConfirmation = {})
 }
 
 @Composable
 @Preview(showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun ReissueDialogDonePreview() {
     ReissueDialog(isApply = false, onDismissRequest = {}, onConfirmation = {})
 }


### PR DESCRIPTION
<img width="330" alt="스크린샷 2023-12-27 오후 5 44 57" src="https://github.com/jaewon55/24hane/assets/68346312/0ebcba2b-94d2-4c7a-8053-c80f6f13a7da">

1. 달력 날짜 box 크기는 40dp로 이전과 같음, 색 채워지는 부분을 40dp -> 30dp 변경
2. 달력의 날짜가 짤리는 버그가 있어 수정
  - 23년 7월의 경우 29일까지만 달력에서 표시됐음
  - 달력의 item의 개수를 정하는 로직에 문제가 있어 수정함
3. 다크모드시 text가 안보이는 문제가 있어 색상 지정
